### PR TITLE
Expand Windows hardening script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ The script performs the following actions to harden a Windows 10 machine:
 7. **Audit Policy Configuration**: Enables auditing for account logon, account management, and logon/logoff activities.
 8. **Disable USB Storage Access**: Restricts access to USB storage to prevent unauthorized data access or malware introduction.
 9. **Remove Unnecessary Software**: Uninstalls outdated or potentially vulnerable software like `Adobe Flash Player` and `Java`.
+10. **Enable Automatic Windows Updates**: Ensures Windows Update is configured to automatically download and install updates.
+11. **Disable SMBv1**: Turns off the legacy and insecure SMBv1 protocol.
+12. **Enable Additional Audit Policies**: Adds auditing for policy change and object access events.
+13. **Disable LLMNR**: Turns off Link-Local Multicast Name Resolution to reduce spoofing risks.
+14. **Disable NetBIOS over TCP/IP**: Disables legacy NetBIOS services on all network adapters.
+15. **Disable AutoRun**: Prevents automatic execution of media to mitigate autorun-based attacks.
+
+The companion `Windows_Server_22.ps1` script applies similar safeguards for Windows Server 2022, including automatic updates,
+SMBv1 removal, and disabling LLMNR, NetBIOS, and AutoRun.
 
 ## Running the Script
 ### Prerequisites


### PR DESCRIPTION
## Summary
- ensure Windows Update service runs automatically before applying policy settings
- remove legacy SMBv1 protocol and disable NetBIOS and AutoRun on Windows Server 2022
- document that the Windows_Server_22.ps1 script now applies these safeguards

## Testing
- `apt-get update`
- `apt-get install -y powershell`
- `pwsh -NoLogo -NoProfile -File Windows_Server_22.ps1` *(fails: Get-WmiObject not recognized; HKLM drive does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c43973404c832cb88c3082376c0218