### PR TITLE
Disable insecure network protocols

### DIFF
--- a/secure_windows.ps1
+++ b/secure_windows.ps1
@@ -201,6 +201,37 @@ try {
     $actionResults += "Disable AutoRun: Failed - $_"
 }
 
+# 16. Disable Legacy Network Protocol Services
+$legacyServices = @(
+    'TlntSvr',  # Telnet
+    'FTPSVC',   # FTP Server
+    'Tftpd',    # TFTP
+    'W3SVC',    # HTTP Web Server (IIS)
+    'SNMP',     # SNMP v1/v2
+    'RshSvc',   # RSH
+    'Rlogon',   # Rlogin
+    'Rexsvc',   # Rexec
+    'POP3Svc',  # POP3
+    'IMAP4Svc', # IMAP
+    'NTDS',     # LDAP
+    'SMTPSVC',  # SMTP
+    'simptcp',  # Finger, Daytime, Echo, Chargen
+    'NfsClnt',  # NFS Client
+    'NfsServer' # NFS Server
+)
+foreach ($service in $legacyServices) {
+    try {
+        $svc = Get-Service -Name $service -ErrorAction SilentlyContinue
+        if ($svc -and $svc.Status -ne 'Stopped') {
+            Set-Service -Name $service -StartupType Disabled -ErrorAction SilentlyContinue
+            Stop-Service -Name $service -ErrorAction SilentlyContinue
+        }
+        $actionResults += "Disable Legacy Service ${service}: Success"
+    } catch {
+        $actionResults += "Disable Legacy Service ${service}: Failed - $_"
+    }
+}
+
 Write-Host "Basic Security Hardening Completed! Please verify manually for any specific CyberPatriot requirements."
 
 # Display summary of actions


### PR DESCRIPTION
## Summary
- Add legacy protocol hardening section to client script to shut down services like FTP, TFTP, HTTP/IIS, SNMP, RSH, Rlogin, Rexec, POP3, IMAP, LDAP, SMTP, Finger/Daytime/Echo/Chargen, and NFS.
- Extend Windows Server 2022 script with the same service shutdowns and explicitly disable SMBv1 and NetBIOS over TCP/IP.

## Testing
- `pwsh -NoLogo -File secure_windows.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68c476fa245c832cb9a66190e6d2320b